### PR TITLE
Add vitest setup with persian utils tests

### DIFF
--- a/client/tests/persian-utils.test.ts
+++ b/client/tests/persian-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { toPersianNumbers, toEnglishNumbers, getTimeAgoPersian } from '../src/lib/persian-utils';
+
+describe('persian utils', () => {
+  it('converts english numbers to persian', () => {
+    expect(toPersianNumbers('1234567890')).toBe('۱۲۳۴۵۶۷۸۹۰');
+    expect(toPersianNumbers(9870)).toBe('۹۸۷۰');
+  });
+
+  it('converts persian numbers to english', () => {
+    expect(toEnglishNumbers('۱۲۳۴۵۶۷۸۹۰')).toBe('1234567890');
+    expect(toEnglishNumbers('۱۲۳abc۴۵')).toBe('123abc45');
+  });
+
+  describe('getTimeAgoPersian', () => {
+    it('handles recent times', () => {
+      const date = new Date(Date.now() - 30 * 60 * 1000);
+      expect(getTimeAgoPersian(date)).toBe('اکنون');
+    });
+
+    it('handles hours and days', () => {
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      expect(getTimeAgoPersian(twoHoursAgo)).toBe('۲ ساعت پیش');
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      expect(getTimeAgoPersian(yesterday)).toBe('دیروز');
+    });
+
+    it('handles weeks and months', () => {
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+      expect(getTimeAgoPersian(tenDaysAgo)).toBe('۱ هفته پیش');
+
+      const fortyFiveDaysAgo = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000);
+      expect(getTimeAgoPersian(fortyFiveDaysAgo)).toBe('۱ ماه پیش');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -101,7 +102,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "vitest": "^1.5.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['client/tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- add vitest configuration
- create tests for persian utils
- add vitest to dev dependencies and test script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fab856ec832eac0a82b9758924c2